### PR TITLE
Automatic connection recovery

### DIFF
--- a/test/MockServer.hs
+++ b/test/MockServer.hs
@@ -73,7 +73,7 @@ runMockServer = do
 stopMockServer :: Serialize a => MockServer a -> IO ()
 stopMockServer server = do
   killThread $ mockServerThread server
-  (mapM_ killThread . S.toList) =<< (readMVar $ mockServerConnectionThreads server)
+  (mapM_ killThread . S.toList) =<< (swapMVar (mockServerConnectionThreads server) S.empty)
   threadDelay 10000
 
 getConnectionCount :: MockServer a -> IO Int

--- a/test/MockServer.hs
+++ b/test/MockServer.hs
@@ -73,6 +73,7 @@ runMockServer = do
 stopMockServer :: Serialize a => MockServer a -> IO ()
 stopMockServer server = do
   killThread $ mockServerThread server
+  (mapM_ killThread . S.toList) =<< (readMVar $ mockServerConnectionThreads server)
   threadDelay 10000
 
 getConnectionCount :: MockServer a -> IO Int


### PR DESCRIPTION
Looks like my last pull-request made a regression that the logger never tries to reconnect when the connection is lost. Sorry about that. This patch should fix the problem.

Summary:

- Enabled test `postBuffersMessageIfLostConnection`, which was commented out (why?).
- Fixed MockServer so that it disconnects all connections when stopped.
- Now Logger catches exception raised by `sendAll`, so it can recover the connection.
- Now Logger tries to receive data from the socket, so it can detect disconnect from the server.
